### PR TITLE
Revert "Layout: export Media and Size props"

### DIFF
--- a/packages/argo-checkout-react/src/index.ts
+++ b/packages/argo-checkout-react/src/index.ts
@@ -25,8 +25,6 @@ export type {
   ImageProps,
   InlineStackProps,
   LayoutProps,
-  LayoutMediaProps,
-  LayoutSizeProps,
   LinkProps,
   RadioProps,
   SelectProps,

--- a/packages/argo-checkout/src/components/Layout/Layout.ts
+++ b/packages/argo-checkout/src/components/Layout/Layout.ts
@@ -46,11 +46,11 @@ export interface LayoutProps {
  * - `0.5` represents `50%`
  * - `1` represents `100%`
  */
-export type Size = 'auto' | 'fill' | number;
+type Size = 'auto' | 'fill' | number;
 
 type ViewportSize = 'small' | 'medium' | 'large';
 
-export interface Media {
+interface Media {
   /*
    * Specifies the viewport size these instruction will apply to.
    */

--- a/packages/argo-checkout/src/components/Layout/index.ts
+++ b/packages/argo-checkout/src/components/Layout/index.ts
@@ -1,6 +1,2 @@
 export {Layout} from './Layout';
-export type {
-  LayoutProps,
-  Size as LayoutSizeProps,
-  Media as LayoutMediaProps,
-} from './Layout';
+export type {LayoutProps} from './Layout';

--- a/packages/argo-checkout/src/components/index.ts
+++ b/packages/argo-checkout/src/components/index.ts
@@ -25,7 +25,7 @@ export type {ImageProps} from './Image';
 export {InlineStack} from './InlineStack';
 export type {InlineStackProps} from './InlineStack';
 export {Layout} from './Layout';
-export type {LayoutProps, LayoutMediaProps, LayoutSizeProps} from './Layout';
+export type {LayoutProps} from './Layout';
 export {Link} from './Link';
 export type {LinkProps} from './Link';
 export {Radio} from './Radio';

--- a/packages/argo-checkout/src/index.ts
+++ b/packages/argo-checkout/src/index.ts
@@ -29,8 +29,6 @@ export type {
   ImageProps,
   InlineStackProps,
   LayoutProps,
-  LayoutMediaProps,
-  LayoutSizeProps,
   LinkProps,
   RadioProps,
   SelectProps,


### PR DESCRIPTION
Reverts Shopify/argo-checkout#24

Found a better way to access those from LayoutProps