### PR TITLE
fix missing spinner

### DIFF
--- a/packages/argo-checkout-react/src/components/index.ts
+++ b/packages/argo-checkout-react/src/components/index.ts
@@ -16,6 +16,7 @@ export {Link} from './Link';
 export {Radio} from './Radio';
 export {Select} from './Select';
 export {Separator} from './Separator';
+export {Spinner} from './Spinner';
 export {Text} from './Text';
 export {TextBlock} from './TextBlock';
 export {TextContainer} from './TextContainer';


### PR DESCRIPTION
🎩 
In this repo on this branch

```
yarn
yarn build
cd packages/yarn-checkout-react
yarn link
cd ../..
cd packages/yarn-checkout
yarn link
```

Create a new project based on our template.
Run

```
yarn
yarn link "@shopify/argo-checkout" && yarn link "@shopify/argo-checkout-react"
yarn server
```

Put `Spinner` somewhere

Finish checkout to post purchase page, see the spinner working