### PR TITLE
[Cross sells] Update postpurchase types to latest

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/index.ts
@@ -3,6 +3,5 @@ export type {
   PostPurchaseShouldRenderApi,
   PostPurchaseShouldRenderResult,
   ChangeType,
-  ChangesetProcessingStatus,
   ExplicitDiscountType,
 } from './post-purchase';


### PR DESCRIPTION
1. Add shipping lines
1. Split calculate and apply outputs into their own types
1. Updated output of `calculate` to remove partial option, and remove `updatedPurchase` on error
1. Updated output of `apply` to remove purchase response.
1. Remove `changesetProcessingStatus` export - it's inline now
1. Add new `add_shipping_line` operation in `ChangeType`
1. Add new `ShippingLineChange` etc.


Edit on Aug 18:
> I just pushed another change:
> 
> `updatedPurchase` -> `calculatedPurchase`
> `UpdatedPurchase` -> `CalculatedPurchase`

