### PR TITLE
improve autocompletion for CalculateChangesetResult.calculatedPurchase

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -194,6 +194,7 @@ type CalculateChangesetResult =
   | {
       errors: ChangesetError[];
       status: 'unprocessed';
+      calculatedPurchase?: never;
     }
   | {
       errors: ChangesetError[];


### PR DESCRIPTION
issue h/t @jared-dykstra 

When you used TS autocomplete on a `CalculateChangesetResult`, it would never show `calculatedPurchase` unless you type-guarded it with a `status === 'processed'`

This PR changes it so that if you don't check the status, `calculatedPurchase` is available, but optional. So you'd still have to manually ensure that it exists.
 
if you check for `status === 'processed'`, `calculatedPurchase` is available and not-optional.

if you check for `status === 'unprocessed'` and try to access `calculatedPurchase` TS will produce an error.
