### PR TITLE
read config and provide query string

### DIFF
--- a/packages/argo-run/package.json
+++ b/packages/argo-run/package.json
@@ -14,6 +14,7 @@
     "@types/glob": "^7.1.1",
     "@types/koa": "^2.11.3",
     "@types/koa-webpack": "^5.0.1",
+    "@types/js-yaml": "^3.12.5",
     "@types/webpack": "^4.41.13"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
     "get-port": "^5.1.1",
     "glob": "^7.1.6",
     "gzip-size": "^5.1.1",
+    "js-yaml": "^3.14.0",
     "koa": "^2.11.0",
     "koa-webpack": "^5.3.0",
     "open": "^7.0.4",

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -15,6 +15,7 @@ export async function dev(...args: string[]) {
   const publicPath = `${url}/assets/`;
   const filename = 'extension.js';
   const fileUrl = `${publicPath}${filename}`;
+  const configPath = `/config`;
 
   const compiler = webpack(
     createWebpackConfiguration({
@@ -61,6 +62,15 @@ export async function dev(...args: string[]) {
       },
     },
   });
+
+  if (extensionConfig) {
+    app.use(async (ctx, next) => {
+      if (ctx.path !== configPath) {
+        return next();
+      }
+      ctx.body = extensionConfig;
+    });
+  }
 
   app.use(middleware);
 

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -88,12 +88,12 @@ export async function dev(...args: string[]) {
 
   log(`Your extension is available at ${fileUrl}`);
 
-  // XXX we should replace this with a check for extension type
+  // we could replace this with a check for extension type
   // to only show the query parameters for post purchase extensions
   if (extensionConfig) {
     const query = new URLSearchParams();
-    query.set('script_url', fileUrl);
 
+    query.set('script_url', fileUrl);
     query.set('config', JSON.stringify(extensionConfig));
 
     log(`You can append this query string: ${query.toString()}`);

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -133,7 +133,9 @@ function readConfig() {
 
   try {
     return loadYaml(readFileSync(configPath, 'utf8'));
-  } catch {
+  } catch (error) {
+    log('Failed parsing extension.config.yml', {error: true});
+    log(error, {error: true});
     return null;
   }
 }

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -1,5 +1,7 @@
 import {URL, URLSearchParams} from 'url';
+import {readFileSync, existsSync} from 'fs';
 import {resolve, join} from 'path';
+import {safeLoad as loadYaml} from 'js-yaml';
 import getPort from 'get-port';
 import webpack from 'webpack';
 import Koa from 'koa';
@@ -124,9 +126,13 @@ function getOpenUrl(args: string[]) {
 }
 
 function readConfig() {
-  const path = resolve(join(process.cwd(), 'extension.config.json'));
+  const configPath = resolve(join(process.cwd(), 'extension.config.yml'));
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
   try {
-    return require(path);
+    return loadYaml(readFileSync(configPath, 'utf8'));
   } catch {
     return null;
   }


### PR DESCRIPTION
fixes https://github.com/Shopify/cross-sell-app/issues/188

Reads `config.extension.yml` and prints the content as copy/pastable query string to the terminal. 
Partners can copy paste this to apply metafields during development. (not implemented in core yet)

This also exposes a `/config` endpoint which responds with the config as json.
The endpoint is going to be used by our extension to automatically append the config, just like we're doing for the script_url itself. (PR for that will follow)

🎩 

We'll use a test branch in the `argo-checkout-template` repo with a locally built and linked argo-run (package in this repo) version. 

Make sure, you have all the repos:

```
dev clone argo-checkout
dev clone argo-checkout-template
```

prepare this branch and build all the things™
```
dev cd argo-checkout
git fetch
git checkout config-query
yarn
yarn build
```

Prepare the top hat branch
```
dev cd argo-checkout-template
git fetch
git checkout tophat-config
yarn
```

🔗  it all together
```
yarn link --cwd $(dev cd -n argo-checkout)/packages/argo-checkout
yarn link --cwd $(dev cd -n argo-checkout-template) "@shopify/argo-run"
```

serve
```
dev cd argo-checkout-template
yarn server
```

You should see an output like: 

```
🔭 > Starting dev server on http://localhost:39351
🔭 > Your extension is available at http://localhost:39351/assets/extension.js
🔭 > You can append this query string: script_url=http%3A%2F%2Flocalhost%3A39351%2Fassets%2Fextension.js&config=%7B%22metafields%22%3A%5B%7B%22namespace%22%3A%22my-app%22%2C%22key%22%3A%22first-key%22%7D%2C%7B%22namespace%22%3A%22my-app%22%2C%22key%22%3A%22second-key%22%7D%5D%7D
```

Take a look at `config.extension.yml` to familiarize yourself with its content.


Start a checkout until the payments page.
Append (or replace if the browser extension already added script_url) the mentioned query string.

Open the console:

```
JSON.parse(new URLSearchParams(location.search).get('config'))
```
Should log metafield arrays.


Go to 

 http://localhost:39351/config and check that it responds with config json

If you delete or empty or put invaid yml inside `extension.config.yml`  the endpoint should return 404 and the terminal should not show the query string output. 

In case of an invalid file, it should, however, show that error. 

