### PR TITLE
Add domain to shop

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -64,6 +64,7 @@ interface Purchase {
 
 interface Shop {
   id: number;
+  domain: string;
   /**
    * Only public listed metafields are available
    * https://shopify.dev/tutorials/retrieve-metafields-with-storefront-api#expose-metafields-to-the-storefront-api


### PR DESCRIPTION
Doing this so we can get rid of the `ShopWithDomain` hack in https://github.com/Shopify/post-purchase-reference-extension/pull/27.