### PR TITLE
Adding Banner component

### DIFF
--- a/packages/argo-checkout/src/components/Banner/Banner.ts
+++ b/packages/argo-checkout/src/components/Banner/Banner.ts
@@ -1,10 +1,11 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 /**
-   * Info:
-   * Use to convey general information or actions that aren’t critical or tied to a particular action. 
- 
-   * Success:
+ * Info:
+ * Use to convey general information or actions that aren’t critical or tied to
+ * a particular action.
+ *
+ * Success:
  * Use rarely, only if you need additional visual confirmation that a
  * non-standard action has been completed successfully, for example adding an
  * item to an order as an upsell.

--- a/packages/argo-checkout/src/components/Banner/Banner.ts
+++ b/packages/argo-checkout/src/components/Banner/Banner.ts
@@ -1,0 +1,43 @@
+import {createRemoteComponent} from '@remote-ui/core';
+
+/**
+ * Success:
+ * Use rarely, only if you need additional visual confirmation that a
+ * non-standard action has been completed successfully, for example adding an
+ * item to an order as an upsell.
+ *
+ * Warning:
+ * Use to display information that needs attention or that customers need to
+ * take action on. Seeing these banners can be stressful for customers so be
+ * cautious about using them. Does not block progress to next step.
+ *
+ * Critical:
+ * Use to communicate problems that have to be resolved immediately for
+ * customers to complete a task. For example, using a different payment method
+ * if card details couldn't be processed. Seeing these banners can be stressful
+ * for customers so be cautious about using them.
+ */
+type Status = 'info' | 'success' | 'warning' | 'critical';
+
+export interface BannerProps {
+  /**
+   * Banners have an optional title. Use a title to grab the buyers attention
+   * with a short, concise message.
+   */
+  title?: string;
+  /**
+   * What status icon & color scheme to use
+   * @default 'info'
+   */
+  status?: Status;
+  /** Makes the content collapsible */
+  collapsible?: boolean;
+  /** Hides the status icon */
+  iconHidden?: boolean;
+}
+
+/**
+ * A Banner is used to give feedback and is typically displayed at the top of a
+ * page or section.
+ */
+export const Banner = createRemoteComponent<'Banner', BannerProps>('Banner');

--- a/packages/argo-checkout/src/components/Banner/Banner.ts
+++ b/packages/argo-checkout/src/components/Banner/Banner.ts
@@ -1,7 +1,10 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 /**
- * Success:
+   * Info:
+   * Use to convey general information or actions that aren’t critical or tied to a particular action. 
+ 
+   * Success:
  * Use rarely, only if you need additional visual confirmation that a
  * non-standard action has been completed successfully, for example adding an
  * item to an order as an upsell.
@@ -26,7 +29,7 @@ export interface BannerProps {
    */
   title?: string;
   /**
-   * What status icon & color scheme to use
+   * Sets the status of the banner.
    * @default 'info'
    */
   status?: Status;

--- a/packages/argo-checkout/src/components/Banner/README.md
+++ b/packages/argo-checkout/src/components/Banner/README.md
@@ -1,0 +1,9 @@
+# Banner
+
+A Banner is used to give feedback and is typically displayed at the top of a page or section.
+
+## Props
+
+required = \*
+
+<table><tr><th>Name</th><th>Type</th><th>Description</th></tr><tr><td>title</td><td><code>string</code></td><td>Banners have an optional title. Use a title to grab the buyers attention with a short, concise message.</td></tr><tr><td>status</td><td><code>"info"</code> | <code>"success"</code> | <code>"warning"</code> | <code>"critical"</code></td><td>What status icon & color scheme to use</td></tr><tr><td>collapsible</td><td><code>boolean</code></td><td>Makes the content collapsible</td></tr><tr><td>iconHidden</td><td><code>boolean</code></td><td>Hides the status icon</td></tr></table>

--- a/packages/argo-checkout/src/components/Banner/index.ts
+++ b/packages/argo-checkout/src/components/Banner/index.ts
@@ -1,0 +1,2 @@
+export {Banner} from './Banner';
+export type {BannerProps} from './Banner';

--- a/packages/argo-checkout/src/components/index.ts
+++ b/packages/argo-checkout/src/components/index.ts
@@ -1,3 +1,5 @@
+export {Banner} from './Banner';
+export type {BannerProps} from './Banner';
 export {BlockStack} from './BlockStack';
 export type {BlockStackProps} from './BlockStack';
 export {Bookend} from './Bookend';


### PR DESCRIPTION
This PR adds a Banner component (from checkout-web-ui)

<img width="586" alt="Screen Shot 2020-09-02 at 11 18 27 AM" src="https://user-images.githubusercontent.com/132806/92009378-0d7f6800-ed0e-11ea-8de6-1dc5eeab06a8.png">

```jsx
<Banner title="This is an informative message" />
<Banner status="success" title="This is a success message" />
<Banner status="warning" title="This is a warning message" />
<Banner status="critical" title="This is an error message" />
<Banner title="This is a message with content">
  <Text>
    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Dolores
    commodi, vitae explicabo, laudantium consequatur eaque dignissimos
    dolorem optio minus porro nesciunt magni reprehenderit accusamus quasi
    sit architecto sequi nihil.
  </Text>
</Banner>
```