### PR TITLE
[Cross Sells] Support JWT/string input on calculateChangeset JS

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -30,7 +30,7 @@ export interface PostPurchaseRenderApi
   shop: Shop;
   /** Returns the calculations that would result from the provided changeset being applied. Used to provide cost-clarity for buyers. */
   calculateChangeset(
-    changeset: Readonly<Changeset>,
+    changeset: Readonly<Changeset> | string,
   ): Promise<CalculateChangesetResult>;
   /**  Requests a changeset to be applied to the initial purchase, and to charge the buyer with the difference in total price, if any. */
   applyChangeset(


### PR DESCRIPTION
Depends on https://github.com/Shopify/shopify/pull/258829

Part 2/2 of https://github.com/Shopify/cross-sell-app/issues/231
Fixes https://github.com/Shopify/cross-sell-app/issues/231

---
This PR changes the expected input type for `calculateChangeset` to either be a `Changeset` (array of changes) or a string (assumed to be a JWT).