### PR TITLE
Add banner to argo-checkout-react

### DIFF
--- a/packages/argo-checkout-react/src/components/Banner.ts
+++ b/packages/argo-checkout-react/src/components/Banner.ts
@@ -1,0 +1,4 @@
+import {Banner as BaseBanner} from '@shopify/argo-checkout';
+import {createRemoteReactComponent} from '@remote-ui/react';
+
+export const Banner = createRemoteReactComponent(BaseBanner);

--- a/packages/argo-checkout-react/src/components/index.ts
+++ b/packages/argo-checkout-react/src/components/index.ts
@@ -1,3 +1,4 @@
+export {Banner} from './Banner';
 export {BlockStack} from './BlockStack';
 export {Bookend} from './Bookend';
 export {Button} from './Button';

--- a/packages/argo-checkout-react/src/index.ts
+++ b/packages/argo-checkout-react/src/index.ts
@@ -10,6 +10,7 @@ export type {
   ReturnTypeForExtension,
   ShopifyGlobal,
   Version,
+  BannerProps,
   BlockStackProps,
   BookendProps,
   ButtonProps,

--- a/packages/argo-checkout/src/components/index.ts
+++ b/packages/argo-checkout/src/components/index.ts
@@ -4,6 +4,7 @@ export {BlockStack} from './BlockStack';
 export type {BlockStackProps} from './BlockStack';
 export {Bookend} from './Bookend';
 export type {BookendProps} from './Bookend';
+export {Button} from './Button';
 export type {ButtonProps} from './Button';
 export {ButtonGroup} from './ButtonGroup';
 export type {ButtonGroupProps} from './ButtonGroup';

--- a/packages/argo-checkout/src/components/index.ts
+++ b/packages/argo-checkout/src/components/index.ts
@@ -4,7 +4,6 @@ export {BlockStack} from './BlockStack';
 export type {BlockStackProps} from './BlockStack';
 export {Bookend} from './Bookend';
 export type {BookendProps} from './Bookend';
-export {Button} from './Button';
 export type {ButtonProps} from './Button';
 export {ButtonGroup} from './ButtonGroup';
 export type {ButtonGroupProps} from './ButtonGroup';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,6 +1733,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-yaml@^3.12.5":
+  version "3.12.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.5.tgz#136d5e6a57a931e1cce6f9d8126aa98a9c92a6bb"
+  integrity sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -6119,7 +6124,7 @@ jest@^26.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.10.0, js-yaml@^3.13.1:
+js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==


### PR DESCRIPTION
Banner was added to `argo-checkout` in #36 but not yet to `argo-checkout-react`

Also updates yarn.lock which I missed prior.

🎩  by running a locally built and linked version of argo-checkout-react:

![image](https://user-images.githubusercontent.com/474248/92145215-e1cfb100-ede5-11ea-8163-f99eac46a248.png)
