### PR TITLE
[Cross Sells] Support JWT/string input on applyChangeset JS

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -33,10 +33,7 @@ export interface PostPurchaseRenderApi
     changeset: Readonly<Changeset>,
   ): Promise<CalculateChangesetResult>;
   /**  Requests a changeset to be applied to the initial purchase, and to charge the buyer with the difference in total price, if any. */
-  applyChangeset(
-    signature: string,
-    changeset: Readonly<Changeset>,
-  ): Promise<ApplyChangesetResult>;
+  applyChangeset(changeset: string): Promise<ApplyChangesetResult>;
   /**
    * Indicates that the extension has finished running.
    * Currently, effectively redirects buyers to the thank you page.


### PR DESCRIPTION
Only works once https://github.com/Shopify/shopify/pull/259794 is merged, but can be shipped early and such.

Related to https://github.com/Shopify/cross-sell-app/issues/232

This PR changes the expected input type for `applyChangeset` to be a string (assumed to be a JWT).

This is intended to be a breaking change as this API will stop supporting non-JWT payloads after partners migrate to this.