### PR TITLE
[Cross Sell] Add metafield on apply

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -33,7 +33,10 @@ export interface PostPurchaseRenderApi
     changeset: Readonly<Changeset> | string,
   ): Promise<CalculateChangesetResult>;
   /**  Requests a changeset to be applied to the initial purchase, and to charge the buyer with the difference in total price, if any. */
-  applyChangeset(changeset: string): Promise<ApplyChangesetResult>;
+  applyChangeset(
+    changeset: string,
+    orderMetafield?: Metafield,
+  ): Promise<ApplyChangesetResult>;
   /**
    * Indicates that the extension has finished running.
    * Currently, effectively redirects buyers to the thank you page.


### PR DESCRIPTION
Relates to: https://github.com/Shopify/cross-sell-app/issues/258

Follow-up for: https://github.com/Shopify/shopify/pull/260807

Adding `orderMetafield` to apply changeset action.