### PR TITLE
expose api key for extension / printed query string

### DIFF
--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -1,13 +1,11 @@
 import {URL, URLSearchParams} from 'url';
-import {readFileSync, existsSync} from 'fs';
-import {resolve, join} from 'path';
-import {safeLoad as loadYaml} from 'js-yaml';
+
 import getPort from 'get-port';
 import webpack from 'webpack';
 import Koa from 'koa';
 import koaWebpack from 'koa-webpack';
 
-import {log, namedArgument} from './utilities';
+import {log, namedArgument, readConfig} from './utilities';
 import {createWebpackConfiguration} from './webpack-config';
 import {openBrowser} from './browser';
 
@@ -123,19 +121,4 @@ export async function dev(...args: string[]) {
 function getOpenUrl(args: string[]) {
   const openArg = namedArgument('open', args);
   return (openArg ?? '').startsWith('http') ? new URL(openArg!) : undefined;
-}
-
-function readConfig() {
-  const configPath = resolve(join(process.cwd(), 'extension.config.yml'));
-  if (!existsSync(configPath)) {
-    return null;
-  }
-
-  try {
-    return loadYaml(readFileSync(configPath, 'utf8'));
-  } catch (error) {
-    log('Failed parsing extension.config.yml', {error: true});
-    log(error, {error: true});
-    return null;
-  }
 }

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -1,11 +1,16 @@
-import {URL, URLSearchParams} from 'url';
+import {URL} from 'url';
 
 import getPort from 'get-port';
 import webpack from 'webpack';
 import Koa from 'koa';
 import koaWebpack from 'koa-webpack';
 
-import {log, namedArgument, readConfig} from './utilities';
+import {
+  getData,
+  convertDataToQueryString,
+  log,
+  namedArgument,
+} from './utilities';
 import {createWebpackConfiguration} from './webpack-config';
 import {openBrowser} from './browser';
 
@@ -16,6 +21,7 @@ export async function dev(...args: string[]) {
   const filename = 'extension.js';
   const fileUrl = `${publicPath}${filename}`;
   const configPath = `/config`;
+  const dataPath = '/data';
 
   const compiler = webpack(
     createWebpackConfiguration({
@@ -27,7 +33,7 @@ export async function dev(...args: string[]) {
     }),
   );
 
-  const extensionConfig = readConfig();
+  const data = getData(fileUrl);
 
   const firstCompilePromise = new Promise((resolve) => {
     let hasResolved = false;
@@ -63,14 +69,24 @@ export async function dev(...args: string[]) {
     },
   });
 
-  if (extensionConfig) {
+  // this will stay here for older versions of the extension and can be removed on 01.10.2020
+  // it's not being DRY'd up to make deletion easier
+  if (data.config) {
     app.use(async (ctx, next) => {
       if (ctx.path !== configPath) {
         return next();
       }
-      ctx.body = extensionConfig;
+      ctx.body = data.config;
     });
   }
+
+  app.use(async (ctx, next) => {
+    if (ctx.path !== dataPath) {
+      return next();
+    }
+
+    ctx.body = data;
+  });
 
   app.use(middleware);
 
@@ -86,16 +102,7 @@ export async function dev(...args: string[]) {
 
   log(`Your extension is available at ${fileUrl}`);
 
-  // we could replace this with a check for extension type
-  // to only show the query parameters for post purchase extensions
-  if (extensionConfig) {
-    const query = new URLSearchParams();
-
-    query.set('script_url', fileUrl);
-    query.set('config', JSON.stringify(extensionConfig));
-
-    log(`You can append this query string: ${query.toString()}`);
-  }
+  log(`You can append this query string: ${convertDataToQueryString(data)}`);
 
   const openUrl = getOpenUrl(args);
 

--- a/packages/argo-run/src/utilities.ts
+++ b/packages/argo-run/src/utilities.ts
@@ -73,11 +73,11 @@ export function readEnvFile() {
 
   for (const entry of lines) {
     const matches = entry.match(/(.*?)=(.*)/);
-    if (!matches || !matches[1] || !matches[2]) {
+    if (!matches || !matches[1]) {
       throw new Error(`Can't parse: ${entry}`);
     }
 
-    parsedEnv[matches[1].trim()] = matches[2].trim();
+    parsedEnv[matches[1].trim()] = (matches[2] || '').trim();
   }
 
   return parsedEnv;

--- a/packages/argo-run/src/utilities.ts
+++ b/packages/argo-run/src/utilities.ts
@@ -1,5 +1,8 @@
-import {resolve} from 'path';
+import {resolve, join} from 'path';
+import {readFileSync, existsSync} from 'fs';
 import chalk from 'chalk';
+
+import {safeLoad as loadYaml} from 'js-yaml';
 
 // Extract `--name x` or `--name=x` from an argv array.
 // Could bring in a CLI arg library, but this is fun practice :)
@@ -31,5 +34,20 @@ export function shouldUseReact() {
     return Object.keys(packageJson.dependencies).includes('react');
   } catch {
     return false;
+  }
+}
+
+export function readConfig() {
+  const configPath = resolve(join(process.cwd(), 'extension.config.yml'));
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    return loadYaml(readFileSync(configPath, 'utf8'));
+  } catch (error) {
+    log('Failed parsing extension.config.yml', {error: true});
+    log(error, {error: true});
+    return null;
   }
 }


### PR DESCRIPTION
Reads `SHOPIFY_API_KEY` from `.env` file and prints it as part of the copy/pastable query parameter string and exposes it on a new new `/data` endpoint.

The current `/config` endpoint was too restricted as it only returned the user defined config. 
I kept the endpoint to allow older versions of the browser extension to still function. We will remove it later.

The new endpoint exposes `config` only as one key of many, which keeps it open for potential later extension.

A new version of the browser extension that automatically appends the `api_key` follows after this PR is merged. 


## 🎩 

We'll use a test branch in the `argo-checkout-template` repo with a locally built and linked argo-run (package in this repo) version. 

Make sure, you have all the repos:

```
dev clone argo-checkout
dev clone argo-checkout-template
```

prepare this branch and build all the things™
```
dev cd argo-checkout
git fetch
git checkout api-key
yarn
yarn build
```

Prepare the top hat branch
```
dev cd argo-checkout-template
git fetch
git checkout tophat-env
yarn
```

🔗  it all together
```
yarn link --cwd $(dev cd -n argo-checkout)/packages/argo-checkout
yarn link --cwd $(dev cd -n argo-checkout-template) "@shopify/argo-run"
```

serve
```
dev cd argo-checkout-template
yarn server
```

You should see an output like: 

```
🔭 > Starting dev server on http://localhost:39351
🔭 > Your extension is available at http://localhost:39351/assets/extension.js
🔭 > You can append this query string: script_url=http%3A%2F%2Flocalhost%3A39351%2Fassets%2Fextension.js&config=%7B%22metafields%22%3A%5B%7B%22namespace%22%3A%22my-app%22%2C%22key%22%3A%22first-key%22%7D%2C%7B%22namespace%22%3A%22my-app%22%2C%22key%22%3A%22second-key%22%7D%5D%7D&api_key=key
```

Take a look at `config.extension.yml` to familiarize yourself with its content.
Check the .env and ensure that it `yarn start` printed the `SHOPIFY_API_KEY` value as
 `api_key`.


Start a checkout until the payments page.
Append (or replace if the browser extension already added script_url) the mentioned query string.

Open the console:

```
JSON.parse(new URLSearchParams(location.search).get('config'))
```
Should log metafield arrays.

```
new URLSearchParams(location.search).get('api_key')
```
Should log metafield arrays.


Go to 

 http://localhost:39351/data and check that it responds with data including config json and api key

Go to
 http://localhost:39351/config and check that it responds with config json. This only exists for older version of the browser extension.


Play around with emptying / deleting the .env file. It should not append api_key in these cases.

