### PR TITLE
Revert "[Cross Sell] Add metafield on apply"

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -33,10 +33,7 @@ export interface PostPurchaseRenderApi
     changeset: Readonly<Changeset> | string,
   ): Promise<CalculateChangesetResult>;
   /**  Requests a changeset to be applied to the initial purchase, and to charge the buyer with the difference in total price, if any. */
-  applyChangeset(
-    changeset: string,
-    orderMetafield?: Metafield,
-  ): Promise<ApplyChangesetResult>;
+  applyChangeset(changeset: string): Promise<ApplyChangesetResult>;
   /**
    * Indicates that the extension has finished running.
    * Currently, effectively redirects buyers to the thank you page.


### PR DESCRIPTION
Reverts Shopify/argo-checkout#43 in favour of moving metafield input into `changes` content as another change type.