### PR TITLE
Update remote-ui dependencies

### DIFF
--- a/packages/argo-checkout-react/package.json
+++ b/packages/argo-checkout-react/package.json
@@ -9,7 +9,7 @@
   "sideEffects": false,
   "license": "MIT",
   "dependencies": {
-    "@remote-ui/react": "^1.0.5",
+    "@remote-ui/react": "^2.0.0",
     "@shopify/argo-checkout": "^0.5.4",
     "@types/react": "^16.0.0"
   },

--- a/packages/argo-checkout-react/src/render.ts
+++ b/packages/argo-checkout-react/src/render.ts
@@ -27,6 +27,9 @@ export function render<ExtensionPoint extends RenderExtensionPoint>(
           render(input as InputForRenderExtension<ExtensionPoint>),
         ),
         root,
+        () => {
+          root.mount();
+        },
       );
 
       return {};

--- a/packages/argo-checkout/package.json
+++ b/packages/argo-checkout/package.json
@@ -9,6 +9,6 @@
   "sideEffects": false,
   "license": "MIT",
   "dependencies": {
-    "@remote-ui/core": "^1.2.1"
+    "@remote-ui/core": "^1.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,13 @@
   dependencies:
     "@babel/types" "^7.10.3"
 
+"@babel/helper-module-imports@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
+  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-module-transforms@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz#24e2f08ee6832c60b157bb0936c86bef7210c622"
@@ -208,6 +215,11 @@
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz#aac45cccf8bc1873b99a85f34bceef3beb5d3244"
   integrity sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==
+
+"@babel/helper-plugin-utils@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
+  integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
 "@babel/helper-regex@^7.10.1":
   version "7.10.1"
@@ -256,6 +268,11 @@
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz#60d9847f98c4cea1b279e005fdb7c28be5412d15"
   integrity sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helper-wrap-function@^7.10.1":
   version "7.10.1"
@@ -750,6 +767,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.1"
 
+"@babel/plugin-transform-runtime@^7.10.3":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz#f108bc8e0cf33c37da031c097d1df470b3a293fc"
+  integrity sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz#e8b54f238a1ccbae482c4dce946180ae7b3143f3"
@@ -970,6 +997,15 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.3"
     lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.4":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
+  integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1233,49 +1269,49 @@
     native-url "^0.2.6"
     schema-utils "^2.6.5"
 
-"@remote-ui/core@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-1.2.1.tgz#576a9a3d6e4a63454486c0bc9d72351416e02c83"
-  integrity sha512-79338WYAxp2oCGTDLwmnKiPMGF2A+gY6dICrH4PXW0ftpy9r5tcTaqEx9M0pk6Jq4qxjwWA8Vg8m2r3/IC9COw==
+"@remote-ui/core@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/core/-/core-1.4.0.tgz#c69025cfc4bc86ac55cc5e02ea791211cd3073bb"
+  integrity sha512-TGqqIy/KC9VhHue6hAp+VqxYPUItNLQT6LLX5WKbzN0vipbrW5V1GGjkWvB9TVi2SjurXXt4Bb6JeYSNq26dWw==
   dependencies:
-    "@remote-ui/rpc" "^1.0.2"
-    "@remote-ui/types" "^1.0.2"
+    "@remote-ui/rpc" "^1.0.4"
+    "@remote-ui/types" "^1.0.4"
 
-"@remote-ui/react@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-1.0.5.tgz#84a72f43d540987e90099315d850bf5dfecee724"
-  integrity sha512-Clv1w2j3OVt0KIlZJpy0YPkcKbZn9fvHEjmQ4Jvf8TjE/K2Hz+KDQppDVYq1VTTwXpDc4WG6vC0rRrqiHqroEQ==
+"@remote-ui/react@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@remote-ui/react/-/react-2.0.0.tgz#6a5d6636d1d0bad4eb1288327fcd9d02dd5b6ebe"
+  integrity sha512-yKFqeEBw91Bp4LFW5RpxhiBEVXJRkt8q0L09hzbsmN+oFImwH/f5MVgqQBSv801uG8mmZQm4JmK87AQIYbj2sg==
   dependencies:
-    "@remote-ui/core" "^1.2.1"
-    "@remote-ui/rpc" "^1.0.2"
-    "@remote-ui/web-workers" "^1.0.2"
+    "@remote-ui/core" "^1.4.0"
+    "@remote-ui/rpc" "^1.0.4"
+    "@remote-ui/web-workers" "^1.1.2"
     "@types/react" ">=16.8.0 <17.0.0"
     react-reconciler "^0.25.0"
 
-"@remote-ui/rpc@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.0.2.tgz#6cb3cc8af9913461e26d61877e9816899c18bd0e"
-  integrity sha512-Kanofch4d8brmzlkrDhFy7t3Fba4HyxcX0w7e3LIYbx7z7HHyFB5PDV41KwqwA4t/IaOz9Ufyl1krMWswkosVQ==
+"@remote-ui/rpc@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@remote-ui/rpc/-/rpc-1.0.4.tgz#ad0c21f73e0b13d3d5c44d0b617e28cad69788fa"
+  integrity sha512-YttOiVM13ETOsHT+66JzIb+CUApHvviLhDQszrZv7G8wBQWK1E36s1Cn77hGhu8yMF46ohUxdVHdF4CIHW+wag==
 
-"@remote-ui/types@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/types/-/types-1.0.2.tgz#856468e8fdf51a3ffced49412963b558d06b6c76"
-  integrity sha512-t2r6FaHTkU29Nx3EV20zl8kdBRxkp9otKmJhV3mM8big2H1DuL0BVzKLKRpN89pQCsT12D6ok7Cxq2pqAAo40w==
+"@remote-ui/types@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@remote-ui/types/-/types-1.0.4.tgz#3697205e4048c9fe7fdc1e873ff51a3bbe1b7b92"
+  integrity sha512-iTUzrmiFrbfFNJ4HHI+JIhOSY5+PyLC6pg2RSGFjrxrLebKpLpKZuyahwpA1RfKKKN4mhF7aPVhkDUjkJfkHIA==
 
-"@remote-ui/web-workers@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@remote-ui/web-workers/-/web-workers-1.0.2.tgz#00525823ce8a0d32bb4894f6b1dc4b522548de7e"
-  integrity sha512-kSLsWLKw1oxizvGL41nCPFb3ZNBEwWeZjSw93wFTteo4ElWBWB+X/l8BGFytkEv5IcuFFRxOEs85IsQUKrJE7g==
+"@remote-ui/web-workers@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@remote-ui/web-workers/-/web-workers-1.1.2.tgz#b4df49c86228e7bc8fb2abefd1ebb79acc1815ef"
+  integrity sha512-CMCAyv4qOW2SOakOQvnIgKPmoSfAOyY0Rfz6YjL2GmJkD4cjVwupPYjTYq7neEHkfiRhXgTtjttOR5/HQb/8SA==
   dependencies:
-    "@remote-ui/rpc" "^1.0.2"
-    "@sewing-kit/plugins" "^0.1.0"
+    "@remote-ui/rpc" "^1.0.4"
+    "@sewing-kit/plugins" "^0.1.4"
     "@types/webpack" "^4.41.12"
     loader-utils "^2.0.0"
-    webpack-virtual-modules "^0.2.2"
+    webpack-virtual-modules "^0.3.0"
   optionalDependencies:
     "@babel/core" "^7.9.0"
-    "@sewing-kit/plugin-javascript" "^0.1.3"
-    "@sewing-kit/plugin-webpack" "^0.1.0"
+    "@sewing-kit/plugin-javascript" "^0.1.10"
+    "@sewing-kit/plugin-webpack" "^0.1.6"
     webpack "^4.43.0"
 
 "@sewing-kit/cli@^0.1.0":
@@ -1321,6 +1357,16 @@
   dependencies:
     execa "^4.0.0"
 
+"@sewing-kit/core@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@sewing-kit/core/-/core-0.1.3.tgz#9bd646876fb24734cb13d8ac058ad4346b7c662b"
+  integrity sha512-CobUok52zak+AlRl/Mu1cse6RO5ogp8tWyb8wmBQ1JRR25qRkNbnjSf+dvTk4olWDKXxa5lH4buddSzKujhwPw==
+  dependencies:
+    "@types/fs-extra" "^9.0.0"
+    "@types/glob" "^7.1.1"
+    fs-extra "^9.0.0"
+    glob "^7.1.6"
+
 "@sewing-kit/eslint-plugin@^0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@sewing-kit/eslint-plugin/-/eslint-plugin-0.0.14.tgz#ffd93cc9fffe00a6a1df04fafb19797f64aef3f4"
@@ -1354,6 +1400,13 @@
   integrity sha512-ldFLJpXHmhFP0AAfd0wpzkiRRSNXKQ4nAjsLkgqxnnnirGWT8gojzI5FPlXmafkksRyEszWkV+KyN77RXwubpg==
   dependencies:
     "@sewing-kit/core" "^0.0.39"
+
+"@sewing-kit/hooks@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@sewing-kit/hooks/-/hooks-0.1.5.tgz#7e02eb17e61a7068a8f53df627852c5c7017747c"
+  integrity sha512-k0fmLe9DAvImImazGp6MMhVAFzaKgIF7AcOoZiqOdLWwS9Co9lTvs4KHG1MZehAZyL6vw6SnVmVXDCXQMq3QQg==
+  dependencies:
+    "@sewing-kit/core" "^0.1.3"
 
 "@sewing-kit/model@^0.0.15":
   version "0.0.15"
@@ -1395,6 +1448,30 @@
     node-object-hash "^2.0.0"
   optionalDependencies:
     "@sewing-kit/plugin-webpack" "^0.1.0"
+    webpack ">=4 <5"
+
+"@sewing-kit/plugin-javascript@^0.1.10":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@sewing-kit/plugin-javascript/-/plugin-javascript-0.1.17.tgz#acedf5a49baf1e08da2643e345a72ace12732b74"
+  integrity sha512-5qlt1baS9ynMcSOaUq7OgoiQYUkYJBnpyNRO8bXsax+tp05JKV3Qgfc6/LfurdFcsQ6eVyp3bvF5e+XE9I65Hg==
+  dependencies:
+    "@babel/cli" "^7.8.4"
+    "@babel/core" "^7.8.0"
+    "@babel/plugin-proposal-class-properties" "^7.8.3"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-proposal-numeric-separator" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.9.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-runtime" "^7.10.3"
+    "@babel/preset-env" "^7.9.5"
+    "@sewing-kit/hooks" "^0.1.5"
+    "@sewing-kit/plugins" "^0.1.5"
+    "@types/babel__core" "^7.1.7"
+    babel-loader "^8.1.0"
+    core-js "^3.6.5"
+    node-object-hash "^2.0.0"
+  optionalDependencies:
+    "@sewing-kit/plugin-webpack" "^0.1.8"
     webpack ">=4 <5"
 
 "@sewing-kit/plugin-jest@^0.1.0", "@sewing-kit/plugin-jest@^0.1.3":
@@ -1529,6 +1606,23 @@
     terser-webpack-plugin "^3.0.1"
     webpack "^4.42.1"
 
+"@sewing-kit/plugin-webpack@^0.1.6", "@sewing-kit/plugin-webpack@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@sewing-kit/plugin-webpack/-/plugin-webpack-0.1.8.tgz#2192b17bbaa837c76b2f5a7386f88975b2bcc8a6"
+  integrity sha512-lbeX+3UJ3LJRMRCI524hlCVGcgEo1eo4amoijs4XM4mqZh8fY/N58sNI0QjOWkrTXfBmTC9hAWnqH4naga5t2w==
+  dependencies:
+    "@sewing-kit/plugins" "^0.1.5"
+    "@sewing-kit/webpack-plugin-hash-output" "^0.0.2"
+    "@types/case-sensitive-paths-webpack-plugin" "^2.1.2"
+    "@types/terser-webpack-plugin" "^2.2.0"
+    "@types/webpack" "^4.41.12"
+    "@types/webpack-merge" "^4.1.5"
+    cache-loader "^4.1.0"
+    case-sensitive-paths-webpack-plugin "^2.3.0"
+    terser-webpack-plugin "^3.0.1"
+    webpack "^4.42.1"
+    webpack-merge "^4.2.2"
+
 "@sewing-kit/plugins@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@sewing-kit/plugins/-/plugins-0.1.0.tgz#027a6b6bf0e4ff49416778e109b55bc61a9ccca6"
@@ -1540,6 +1634,16 @@
     "@sewing-kit/tasks" "^0.1.0"
     change-case "^4.1.0"
 
+"@sewing-kit/plugins@^0.1.4", "@sewing-kit/plugins@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@sewing-kit/plugins/-/plugins-0.1.5.tgz#ba9c64b8a46664f7134e097700f8fd08f76e547c"
+  integrity sha512-kjamB4bGpK9fnrXkPqRIzNpvW1L1Xy8uoNbhC9IDxn+QIN5ieoZLyeRqBqQNpA8YpT/AloDxtl/AKZQlAHNswg==
+  dependencies:
+    "@sewing-kit/core" "^0.1.3"
+    "@sewing-kit/hooks" "^0.1.5"
+    "@sewing-kit/tasks" "^0.1.5"
+    change-case "^4.1.0"
+
 "@sewing-kit/tasks@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@sewing-kit/tasks/-/tasks-0.1.0.tgz#0decff839baa9af0310bab1aac9c1700448688c3"
@@ -1547,6 +1651,14 @@
   dependencies:
     "@sewing-kit/hooks" "^0.1.0"
     "@sewing-kit/model" "^0.0.15"
+
+"@sewing-kit/tasks@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@sewing-kit/tasks/-/tasks-0.1.5.tgz#8be8ada5abb40ec30e3f713a0618c3598142c1eb"
+  integrity sha512-MdKpFaZDPrhWDaSVXMh5WLe0PPlzooPe7sAisoqrnI7VrgPwBqvdKnUosFQY27OlttRHdskMfAbHFYiarjAjwg==
+  dependencies:
+    "@sewing-kit/core" "^0.1.3"
+    "@sewing-kit/hooks" "^0.1.5"
 
 "@sewing-kit/webpack-plugin-hash-output@^0.0.2":
   version "0.0.2"
@@ -1894,6 +2006,13 @@
     "@types/node" "*"
     "@types/webpack" "*"
     "@types/ws" "*"
+
+"@types/webpack-merge@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/webpack-merge/-/webpack-merge-4.1.5.tgz#265fbee4810474860d0f4c17e0107032881eed47"
+  integrity sha512-cbDo592ljSHeaVe5Q39JKN6Z4vMhmo4+C3JbksOIg+kjhKQYN2keGN7dvr/i18+dughij98Qrsfn1mU9NgVoCA==
+  dependencies:
+    "@types/webpack" "*"
 
 "@types/webpack-sources@*":
   version "1.4.0"
@@ -6552,6 +6671,11 @@ lodash@^4.11.1, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -8204,7 +8328,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -8360,7 +8484,7 @@ schema-utils@^2.0.0, schema-utils@^2.6.5, schema-utils@^2.6.6:
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -9601,6 +9725,13 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
+
 webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -9609,10 +9740,10 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-virtual-modules@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz#20863dc3cb6bb2104729fff951fbe14b18bd0299"
-  integrity sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
+webpack-virtual-modules@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.3.1.tgz#78cbf1a41a699890a706e789a682dd1120558bf4"
+  integrity sha512-C9Zbb9rny/SaZJ7gTgJjyB2Qt4G4dbT5rVZywYpyk3L6qyf006RepODREXC4rcQCiTPdZnqnebRq5Chsxg+SgQ==
   dependencies:
     debug "^3.0.0"
 


### PR DESCRIPTION
This PR updates the remote-ui dependencies. I made one breaking change to `@remote-ui/react` that needs to be accounted for: `render()` no longer calls `root.mount()` automatically, but does allow a callback where we can call that method at the same point it was previously being called. This change was made to allow `render` to support more use cases, most notably "taking over" a remote root object that is already mounted.

cc/ @henrytao-me @vividviolet @alanthai the same change will be needed on the admin library.