### PR TITLE
ensure terser does not produce IE 11 incompatible bundles

### DIFF
--- a/packages/argo-run/src/webpack-config.ts
+++ b/packages/argo-run/src/webpack-config.ts
@@ -61,7 +61,7 @@ export function createWebpackConfiguration({
                   `Licenses: ${licenseFilename}`,
               },
               terserOptions: {
-                ecma: 8,
+                ecma: 5,
                 warnings: false,
                 // Per one of the authors of Preact, the extra pass may inline more esmodule imports
                 // @see https://github.com/webpack-contrib/mini-css-extract-plugin/pull/509#issuecomment-599083073


### PR DESCRIPTION
It optimized objects to use shorthand property syntax.

`{setTimeout: setTimeout}` to `{setTimeout}`

Which isn't supported in IE(11).

Changed ecma version to 5 to avoid even more potential surprises. 😬 