### PR TITLE
[Post-Purchase] Remove 'phone' field from 'AddShippingLineChange'

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -134,7 +134,6 @@ interface AddShippingLineChange {
   price: number;
   title?: string;
   presentmentTitle?: string;
-  phone?: string;
 }
 
 interface SetMetafieldChange extends Metafield {


### PR DESCRIPTION
Compatibility update for https://github.com/Shopify/shopify/pull/265637
Resolves https://github.com/Shopify/cross-sell-app/issues/83