### PR TITLE
Remove need to explicitly mount UI

### DIFF
--- a/packages/argo-checkout/README.md
+++ b/packages/argo-checkout/README.md
@@ -14,7 +14,6 @@ shopify.extend('Checkout::PostPurchase::Render', (root, input) => {
   button.appendChild('Buy now');
 
   root.appendChild(button);
-  root.mount();
 });
 ```
 

--- a/packages/argo-checkout/documentation/globals.md
+++ b/packages/argo-checkout/documentation/globals.md
@@ -23,6 +23,8 @@ extend('Checkout::PostPurchase::ShouldRender', (api) => {
 });
 ```
 
+For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](./extension-points.md), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your extension point in checkout. You do not need to explicitly [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) this object; once the callback you registered for this extension point ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
+
 That’s really all the global API you need to know to start writing an Argo extension. You’ll find the documentation for additional APIs that are provided when an extension point is run in the [extension points documentation](./extension-points.md).
 
 ## Web platform globals

--- a/packages/argo-checkout/documentation/globals.md
+++ b/packages/argo-checkout/documentation/globals.md
@@ -23,7 +23,7 @@ extend('Checkout::PostPurchase::ShouldRender', (api) => {
 });
 ```
 
-For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](./extension-points.md), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your extension point in checkout. You do not need to explicitly [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) this object; once the callback you registered for this extension point ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
+For extensions that render UI, like [`Checkout::PostPurchase::ShouldRender`](./extension-points.md), the first argument is always a [`@remote-ui` `RemoteRoot` object](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoteroot) that allows you to render UI components into your extension point in checkout. You do not need to explicitly call [`mount()`](https://github.com/Shopify/remote-ui/tree/main/packages/core#remoterootmount) on this object; once the callback you registered for this extension point ends (or, if it returns a `Promise`, once that promise resolves), your initial UI will be rendered.
 
 That’s really all the global API you need to know to start writing an Argo extension. You’ll find the documentation for additional APIs that are provided when an extension point is run in the [extension points documentation](./extension-points.md).
 

--- a/packages/argo-checkout/documentation/rendering.md
+++ b/packages/argo-checkout/documentation/rendering.md
@@ -18,7 +18,6 @@ extend('Checkout::PostPurchase::Render', (root) => {
 
   button.appendChild('Press me');
   root.appendChild(button);
-  root.mount();
 });
 ```
 
@@ -49,7 +48,6 @@ extend('Checkout::PostPurchase::Render', (root) => {
 
   button.appendChild(buttonText);
   root.appendChild(button);
-  root.mount();
 });
 
 function labelText(pressCount: number) {

--- a/packages/argo-checkout/documentation/testing.md
+++ b/packages/argo-checkout/documentation/testing.md
@@ -65,7 +65,6 @@ export function handleRenderExtension(root, api) {
   });
   button.appendChild(text);
   root.appendChild(button);
-  root.mount();
 }
 ```
 


### PR DESCRIPTION
@mdarveau pointed out that `mount()` seemed weird/ unnecessary. I've always felt a little uncomfortable about it as well; it serves a purpose in preventing remote-ui from sending all the initial UI updates individually, but feels like boilerplate from the perspective of the developer. Manuel suggested just doing the `mount()` implicitly once the function finishes (or resolves, if it's a promise), so I've done the extension side of that change here. Extensions could still call `mount()` explicitly if they want to flush their initial UI before the render function resolves, as there is no penalty to calling `mount()` multiple times.

There will be a follow-up change to the checkout sandbox that actually does the calling of `mount()` at the necessary time that I will open once I have merged this change in and cut a new version of `@shopify/argo-checkout`.