### PR TITLE
include node_modules when transpiling

### DIFF
--- a/packages/argo-run/src/webpack-config.ts
+++ b/packages/argo-run/src/webpack-config.ts
@@ -114,7 +114,7 @@ export function createWebpackConfiguration({
           },
         },
         {
-          test: /\.(ts|tsx)$/,
+          test: /\.(tsx?)$/,
           exclude: /node_modules/,
           use: {
             loader: 'babel-loader',

--- a/packages/argo-run/src/webpack-config.ts
+++ b/packages/argo-run/src/webpack-config.ts
@@ -84,7 +84,7 @@ export function createWebpackConfiguration({
     module: {
       rules: [
         {
-          test: /\.js$/,
+          test: /\.(jsx?|esnext)$/,
           exclude: /node_modules/,
           use: {
             loader: 'babel-loader',
@@ -99,7 +99,8 @@ export function createWebpackConfiguration({
           },
         },
         {
-          test: /\.esnext$/,
+          test: /\.(js|esnext)$/,
+          include: /node_modules/,
           use: {
             loader: 'babel-loader',
             options: {

--- a/packages/argo-run/src/webpack-config.ts
+++ b/packages/argo-run/src/webpack-config.ts
@@ -105,6 +105,7 @@ export function createWebpackConfiguration({
             loader: 'babel-loader',
             options: {
               configFile: false,
+              compact: true,
               ...babelConfig({
                 react: false,
                 typescript: false,


### PR DESCRIPTION
Fixes issues where required modules weren't probably transpiled to work with our browser matrix.
Usually packages are supposed to produce proper ES5 builds, but not all of them do :( 

E.g. `@lightspeed/i18n-number-format` contains rest and spread.

Will come at the expense of slower builds.

🎩 dev and prod build locally with newly created argo-checkout-template project. 
Installed and used `@lightspeed/i18n-number-format` (as this package is known to cause issues) and checked that no rest or spread was to be found anymore.

🎩 prod

```
yarn build
cd build 
npx http-serve -c-1 -p 39351
```

use http://localhost:39351/main.js as script_url

We can always go back to another solution (like allowing consumers to allowlist packages) later.