### PR TITLE
Include peer dependencies when searching for react

### DIFF
--- a/packages/argo-run/src/utilities.ts
+++ b/packages/argo-run/src/utilities.ts
@@ -32,7 +32,10 @@ export function shouldUseReact() {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const packageJson = require(resolve('package.json'));
-    return Object.keys(packageJson.dependencies).includes('react');
+    return (
+      Object.keys(packageJson.dependencies).includes('react')
+      || Object.keys(packageJson.peerDependencies).includes('react')
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
This change allows the package using `argo-run` to share a common react instance with a dependency.

The steps to construct a package structure that requires this change are as follows:

1. A package structure with two packages in parallel:

```
- root
  - react-extension
    - package.react-extension.json
  - shared
    - package.shared.json
  - package.root.json
```

The purpose of doing this is to have allow a third package to make use of the `shared` package. In order to allow the use of React Hooks, the `react-extension` and `shared` packages must shared the same React instance.

`package.root.json`

```json
{
  "name": "root",
  "version": "1.0.0",
  "private": true,
  "workspaces": {
    "packages": [
      "react-extension/**",
      "shared/**"
    ]
  },
  "dependencies": {
    "react": "^17.0.1",
    "react-dom": "^17.0.1"
  },
  "devDependencies": {
    "typescript": "^4.0.5"
  }
}
```

`package.react-extension.json`

```json
{
  "name": "react-extension",
  "version": "1.0.0",
  "license": "MIT",
  "private": true,
  "dependencies": {
    "@shopify/argo-checkout": "^0.7.0",
    "@shopify/argo-checkout-react": "^0.7.0"
  },
  "peerDependencies": {
    "react": "*"
  },
  "devDependencies": {
    "@shopify/argo-run": "^0.2.3"
  },
  "scripts": {
    "build": "argo-run build",
    "server": "yarn start",
    "start": "argo-run serve --port 39351",
    "lint": "eslint 'src/**'"
  }
}

```

`package.shared.json`

```json
{
  "name": "templates",
  "version": "1.0.0",
  "main": "src/index.ts",
  "license": "MIT",
  "private": true
}
```

2. Install. Run `yarn` in the `root` directory.
3. Run using `yarn start`

If `react` is included in the `dependencies` section of `package.react-extension.json`, it will use this version installed in `react-extension/node_modules` rather than `root/node_modules`, which the `shared` package will use. This causes a mismatch which causes Hooks to be unusable.

The following error is received when trying to run `yarn start` without `react` included in the `dependencies` of `react-extension`:

```
yarn run v1.22.4
$ argo-run serve --port 39351
🔭 > Starting dev server on http://localhost:39351
🔭 > Build failed with errors: 
ERROR in ./src/index.tsx 7:38
Module parse failed: Unexpected token (7:38)
File was processed with these loaders:
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| import Render from './render';
| extend(EExtensionPoints.SHOULD_RENDER, shouldRender);
> render(EExtensionPoints.RENDER, () => <Render />);
 @ multi @shopify/argo-webpack-hot-client/worker ./src/index.tsx main[1]
```

