### PR TITLE
Update standard api interface for post purchase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,9 @@
     "typescriptreact"
   ],
   "editor.formatOnSave": true,
-  "eslint.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },

--- a/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-checkout/src/extension-points/api/post-purchase/post-purchase.ts
@@ -1,6 +1,5 @@
 import type {StandardApi} from '../standard';
-import type {ValueOrPromise} from '../shared';
-import {Metafield, MoneyBag} from '../shared';
+import type {ValueOrPromise, Metafield, MoneyBag} from '../shared';
 
 /** Input given to the ShouldRender extension point (Checkout::PostPurchase::ShouldRender) */
 export interface PostPurchaseShouldRenderApi

--- a/packages/argo-checkout/src/extension-points/api/shared.ts
+++ b/packages/argo-checkout/src/extension-points/api/shared.ts
@@ -1,1 +1,70 @@
 export type ValueOrPromise<T> = T extends PromiseLike<any> ? T : T | Promise<T>;
+
+export interface Purchase {
+  /** Initial purchase's unique identifier */
+  referenceId: string;
+  customerId?: string;
+  destinationCountryCode?: string;
+  totalPriceSet: MoneyBag;
+  /** Items being purchased */
+  lineItems: LineItem[];
+}
+
+export interface Shop {
+  id: number;
+  domain: string;
+  /**
+   * Only public listed metafields are available
+   * https://shopify.dev/tutorials/retrieve-metafields-with-storefront-api#expose-metafields-to-the-storefront-api
+   */
+  metafields: Metafield[];
+}
+
+export interface LineItem {
+  /** Product being purchased */
+  product: Product;
+  quantity: number;
+  totalPriceSet: MoneyBag;
+}
+
+export interface Product {
+  id: number;
+  title: string;
+  /** Variant being purchased */
+  variant: Variant;
+
+  /**
+   * only public listed metafields are available
+   * https://shopify.dev/tutorials/retrieve-metafields-with-storefront-api#expose-metafields-to-the-storefront-api
+   */
+  metafields: Metafield[];
+}
+
+export interface Variant {
+  id: number;
+  title: string;
+  /**
+   * Only public listed metafields are available
+   * https://shopify.dev/tutorials/retrieve-metafields-with-storefront-api#expose-metafields-to-the-storefront-api
+   */
+  metafields: Metafield[];
+}
+
+export interface Metafield {
+  key: string;
+  namespace: string;
+  value: string | number;
+  valueType: 'integer' | 'string' | 'json_string';
+}
+
+export interface Money {
+  amount: string;
+  /** In ISO 4217 format */
+  currencyCode: string;
+}
+
+/** Represents an amount in both shop and presentment currencies. */
+export interface MoneyBag {
+  shopMoney: Money;
+  presentmentMoney: Money;
+}

--- a/packages/argo-checkout/src/extension-points/api/standard/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/standard/index.ts
@@ -1,5 +1,5 @@
-import {ExtensionPoint as RegisteredExtensionPoint} from 'extension-points';
-import {Purchase, Shop} from '../shared';
+import type {ExtensionPoint as RegisteredExtensionPoint} from '../../extension-points';
+import type {Purchase, Shop} from '../shared';
 
 export type Version = 'unstable';
 

--- a/packages/argo-checkout/src/extension-points/api/standard/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/standard/index.ts
@@ -1,9 +1,34 @@
+import {ExtensionPoint as RegisteredExtensionPoint} from 'extension-points';
+import {Purchase, Shop} from '../shared';
+
 export type Version = 'unstable';
 
-export interface StandardApi<
-  ExtensionPoint extends import('../../extension-points').ExtensionPoint
-> {
-  version: Version;
-  locale: string;
+export interface InputData<ExtensionPoint extends RegisteredExtensionPoint> {
+  /** Identifier for the extension point */
   extensionPoint: ExtensionPoint;
+  /** Initial purchase */
+  initialPurchase: Purchase;
+  /** Checkout customer locale */
+  locale: string;
+  /** Shop where the checkout/order is from */
+  shop: Shop;
+  /** JWT representing the input_data payload */
+  token: string;
+  /** Post Purchase API version */
+  version: Version;
+}
+
+/** General-purpose, key-value browser storage for extensions */
+export interface Storage {
+  /** Data in the storage during the first load (read-only) */
+  initialData: unknown;
+  /** Updates the storage to the value that it's given */
+  update(data: any): Promise<void>;
+}
+
+export interface StandardApi<ExtensionPoint extends RegisteredExtensionPoint> {
+  /** Input data given to the extension point */
+  inputData: InputData<ExtensionPoint>;
+  /** General purpose storage for extensions */
+  storage: Storage;
 }


### PR DESCRIPTION
## What problem are you trying to solve ?

While following the [Post-purchase getting started guide](https://docs.google.com/document/d/1JqTUEBXWZ2gKC7bfWc0wy7i6zHtHmldd3ef4N3FHoeU/edit#), I noticed that the extension was not rendering the `extensionPoint` field properly from the extension input. This is caused by `useExtensionInput` not returning a value for all of its fields and not respecting its own types.

```
// Expected
The body of this page was rendered by Checkout::PostPurchase::Render

// Actual
The body of this page was rendered by undefined
```

**Example**

![image](https://user-images.githubusercontent.com/17585917/103816119-78310f00-5032-11eb-863a-698c2bfaa306.png)

This led me to investigate on the signature of the `useExtensionInput` hook which returns the `extensionPoint` field, where I noticed that some fields where duplicated.

For instance, here's the types for the `PostPurchaseRenderApi` :

<summary>
<details>

```ts
export interface PostPurchaseRenderApi
  extends StandardApi<'Checkout::PostPurchase::Render'> {
  /** Input data given to the extension point */
  inputData: InputData;
  /** General purpose storage for extensions */
  storage: Storage;
  /** Returns the calculations that would result from the provided changeset being applied. Used to provide cost-clarity for buyers. */
  calculateChangeset(
    changeset: Readonly<Changeset> | string,
  ): Promise<CalculateChangesetResult>;
  /**  Requests a changeset to be applied to the initial purchase, and to charge the buyer with the difference in total price, if any. */
  applyChangeset(changeset: string): Promise<ApplyChangesetResult>;
  /**
   * Indicates that the extension has finished running.
   * Currently, effectively redirects buyers to the thank you page.
   */
  done(): Promise<void>;
}

interface InputData {
  /** Identifier for the extension point */
  extensionPoint: string;
  /** Initial purchase */
  initialPurchase: Purchase;
  /** Checkout customer locale */
  locale: string;
  /** Shop where the checkout/order is from */
  shop: Shop;
  /** JWT representing the input_data payload */
  token: string;
  /** Post Purchase API version */
  version: string;
}
```
</details>
</summary>


And here's the type of the `StandardApi` :

```ts
export interface StandardApi<
  ExtensionPoint extends import('../../extension-points').ExtensionPoint
> {
  version: Version;
  locale: string;
  extensionPoint: ExtensionPoint;
}
```

The issue with the following types is that it requires the following structure :

```ts
// Representation of the type with the types from standard api merged into this interface
interface PostPurchaseRenderApi {
  version: Version;
  locale: string;
  extensionPoint: ExtensionPoint;

  inputData: {
    version: string; // Those three fields are available right above
    locale: string;
    extensionPoint: string;
    // ... more fields
  }

  // Other fields (not related)
  calculateChangeset: () => void,
  done: () => void,
  applyChangeset: () => void,
  storage: Storage;
}
```

**But** here's what the post purchase page is using as input for the post purchase extension render :

(https://github.com/Shopify/shopify/blob/master/app/assets/javascripts/checkout/esnext/post_purchase/post_purchase_page.js#L188-L197)

```js
return window.CheckoutExtensions.render({
          id: EXTENSION_POINT_RENDER,
          script: scriptUrl,
          root,
          themeSettings,
          i18n,
          input: { 
            // This should comply with the standard api and have a version, locale and extension point field
            // But it doesn't 
            inputData,
            done: this.handleDone,
            calculateChangeset: this.handleCalculateChangeset.bind(this),
            applyChangeset: this.handleApplyChangeset.bind(this),
            storage: {
              initialData: storageData,
              update: this.getStorage().set,
            },
          },
          onStopwatchMark,
        });
```

**Ultimately**, this is causing the following :

```tsx
const input = useExtensionInput<'Checkout::PostPurchase::Render'>();
console.log(input.extensionPoint); // undefined
console.log(input.inputData.extensionPoint); // "Checkout::PostPurchase::Render"
```

**Example:**

_**Note 1 (left):** Notice that the same fields are undefined on the root and defined when logging from the `inputData`_
_**Note 2 (right):**_ Here's the exact same extension running on https://argogogo.dev
![image](https://user-images.githubusercontent.com/17585917/103817769-51c0a300-5035-11eb-9d59-5e641ac476de.png)


## How are you solving it ?

There is really two solutions :
1. Update the post purchase JS file in core and pass the parameters in both place. This doesn't break anything existing, but there's redundancy now.
2. Update the Standard api for post purchase and accept `inputData` and `storage` for each extension point. This breaks the shopify CLI typescript example which refers directly to `useExtensionInput().extensionPoint` instead of `useExtensionInput().inputData.extensionPoint`. But it's now _"impossible"_ for a consumer of the `useExtensionInput` hook to refer to the value directly.

There is a big diff because I'm moving some types around, but the only changes are updating the standard api to this shape , which was already respected by both post-purchase extension points:

```ts
export interface StandardApi<ExtensionPoint extends RegisteredExtensionPoint> {
  /** Input data given to the extension point */
  inputData: InputData<ExtensionPoint>;
  /** General purpose storage for extensions */
  storage: Storage;
```

## Notes

* If we are happy with those changes I'll also update the readme for the standard api which would be out of sync. I'll also update the CLI example to refer to `inputData`.
* If you want to reproduce the original issue, you can simply run `shopify create extension` and follow along https://docs.google.com/document/d/1JqTUEBXWZ2gKC7bfWc0wy7i6zHtHmldd3ef4N3FHoeU/edit#
