### PR TITLE
Update local development for checkout extensions

### DIFF
--- a/packages/argo-run/package.json
+++ b/packages/argo-run/package.json
@@ -42,6 +42,7 @@
     "babel-loader": "^8.2.0",
     "brotli-size": "^4.0.0",
     "chalk": "^4.0.0",
+    "camelcase-keys": "^6.0.0",
     "core-js": "^3.0.0",
     "get-port": "^5.1.1",
     "glob": "^7.0.0",

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -103,7 +103,7 @@ export async function dev(...args: string[]) {
           res.send(`
             <html>
               <head>
-                <meta data-react-html="true" name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, viewport-fit=cover">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, viewport-fit=cover">
                 <style>
                   * {
                     box-sizing: border-box;

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -97,7 +97,7 @@ export async function dev(...args: string[]) {
         const origin = `${protocol}://${host}`;
 
         res.set('Content-Type', 'text/html');
-        res.set('Cache-Control', 'no-cache');
+        res.set('Cache-Control', 'no-store');
 
         function renderIndexPage(content: string) {
           res.send(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3959,7 +3959,7 @@ camelcase-keys@^4.0.0:
     map-obj "^2.0.0"
     quick-lru "^1.0.0"
 
-camelcase-keys@^6.2.2:
+camelcase-keys@^6.0.0, camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
   integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==


### PR DESCRIPTION
This PR updates the local development experience for extensions that are detected as being checkout extensions (this detection will rely on the new template being introduced in https://github.com/Shopify/argo-checkout-template/pull/40):

- A new endpoint, `/query` exists. This endpoint fetches the metadata of your extension "workspace". Right now, it will just be a listing of one extension, because that's all our CLI supports. That metadata includes the asset URL and socket URL
- We print instructions for running these new checkout extensions, which goes through the whole "start a tunnel, make a checkout, paste this query param" flow that the developer needs to do next.

cc/ @henrytao-me @vividviolet 