### PR TITLE
Add `paths` arg to components renderer

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -4,7 +4,7 @@ const paths = {
   root: '../checkout-web/packages/argo-checkout',
   devDocsRoot: '../shopify-dev/content/tools/argo-checkout',
   packages: {
-    JavaScript: '../checkout-web/packages/argo-checkout',
+    JS: '../checkout-web/packages/argo-checkout',
     React: '../checkout-web/packages/argo-checkout-react',
   },
   shopifyDevUrl: '/tools/argo-checkout',

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,8 +1,8 @@
 import {renderForShopifyDev} from './typedoc/typedoc';
 
 const paths = {
-  root: '../checkout-web/packages/argo-checkout',
-  devDocsRoot: '../shopify-dev/content/tools/argo-checkout',
+  inputRoot: '../checkout-web/packages/argo-checkout',
+  outputRoot: '../shopify-dev/content/tools/argo-checkout',
   packages: {
     JS: '../checkout-web/packages/argo-checkout',
     React: '../checkout-web/packages/argo-checkout-react',

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,0 +1,13 @@
+import {renderForShopifyDev} from './typedoc/typedoc';
+
+const paths = {
+  root: '../checkout-web/packages/argo-checkout',
+  devDocsRoot: '../shopify-dev/content/tools/argo-checkout',
+  packages: {
+    JavaScript: '../checkout-web/packages/argo-checkout',
+    React: '../checkout-web/packages/argo-checkout-react',
+  },
+  shopifyDevUrl: '/tools/argo-checkout',
+};
+
+renderForShopifyDev(paths);

--- a/scripts/typedoc/typedoc.ts
+++ b/scripts/typedoc/typedoc.ts
@@ -256,7 +256,7 @@ interface FrontMatter {
 function renderYamlFrontMatter(frontMatter: FrontMatter) {
   let matter = '---\n';
 
-  Object.keys(frontMatter).forEach((key) => {
+  (Object.keys(frontMatter) as (keyof FrontMatter)[]).forEach((key) => {
     matter += `${key}: ${frontMatter[key]}\n`;
   });
 


### PR DESCRIPTION
tldr the script now takes a `paths` object to allow for usage in multiple repos. I've only implemented this in `components()` for now (need to do some additional thinking about how we want to output extension point docs for Admin, as it looks a bit different than Checkout).

You should be able to merge this in without breaking anything. There should be no changes to the output: running `yarn run:ts scripts/generate-docs.ts` in this branch should create the same output as the exact same as the existing docs script (actually there’s one `\n` added to the `argo-checkout/index.md` file 😂).