### PR TITLE
Parse and render tsdoc tags in PropertySignature nodes

### DIFF
--- a/scripts/typedoc/typedoc.ts
+++ b/scripts/typedoc/typedoc.ts
@@ -9,6 +9,7 @@ import type {
   RemoteComponent,
   Type,
   PropertySignature,
+  Tag,
 } from './types';
 import {createDependencyGraph, Module} from './utilities/dependency-graph';
 
@@ -297,15 +298,19 @@ function propsTable(
           propDocs ? strip(propDocs.content).replace(/(\r\n|\n|\r)/gm, '') : ''
         }</td></tr>`;
       } else {
+        const content = propDocs
+          ? strip(propDocs.content).replace(/(\r\n|\n|\r)/gm, '')
+          : '';
+        const tags = propDocs?.tags?.length
+          ? propDocs.tags.map(stringifyTag).join('<br/>')
+          : '';
         markdown += `<tr><td>${propName}${
           optional ? '?' : ''
         }</td><td style="word-wrap:break-word;"><code>${propType(
           value,
           exports,
           dir,
-        )}</code></td><td>${
-          propDocs ? strip(propDocs.content).replace(/(\r\n|\n|\r)/gm, '') : ''
-        }</td></tr>`;
+        )}</code></td><td>${content}${tags ? '<br />' : ''}${tags}</td></tr>`;
       }
     },
   );
@@ -313,6 +318,20 @@ function propsTable(
   markdown += '</table>\n\n';
 
   return markdown;
+}
+
+function stringifyTag(tag: Tag) {
+  let string = sentenceCaseTagName(tag.name);
+  if (tag.content) {
+    string += `: <code>${tag.content}</code>`;
+  }
+  return string;
+}
+
+function sentenceCaseTagName(tagName: string) {
+  const input = tagName.slice(1);
+  const result = input.replace(/([A-Z])/g, ' $1').toLowerCase();
+  return result.charAt(0).toUpperCase() + result.slice(1);
 }
 
 function propType(value: any, exports: any[], dir: string): any {

--- a/scripts/typedoc/types.ts
+++ b/scripts/typedoc/types.ts
@@ -1,5 +1,11 @@
+export interface Tag {
+  name: string;
+  content: string;
+}
+
 export interface Documentation {
   content: string;
+  tags?: Tag[];
 }
 
 export interface Documentable {


### PR DESCRIPTION
<img width="864" alt="Screen Shot 2021-04-15 at 5 37 29 PM" src="https://user-images.githubusercontent.com/3248903/114941508-425dac80-9e11-11eb-8330-3bbe226b3bcc.png">

note: it turns out the `@default` we've been using is supposed to be `@defaultValue`, so you'll need to find+replace in the component source before this will work.

This should work with multiple tags, and tags without a value like `@beta`.

Should be able to merge this into `extract-docs` without breaking anything.