### PR TITLE
chore: remove VisuallyHidden from argo-admin

### DIFF
--- a/packages/argo-admin-react/src/components/VisuallyHidden.ts
+++ b/packages/argo-admin-react/src/components/VisuallyHidden.ts
@@ -1,4 +1,0 @@
-import {VisuallyHidden as BaseVisuallyHidden} from '@shopify/argo-admin';
-import {createRemoteReactComponent} from '@remote-ui/react';
-
-export const VisuallyHidden = createRemoteReactComponent(BaseVisuallyHidden);

--- a/packages/argo-admin-react/src/components/index.ts
+++ b/packages/argo-admin-react/src/components/index.ts
@@ -19,4 +19,3 @@ export * from './StackItem';
 export * from './Text';
 export * from './TextField';
 export * from './Thumbnail';
-export * from './VisuallyHidden';

--- a/packages/argo-admin/src/component-sets/Basic.ts
+++ b/packages/argo-admin/src/component-sets/Basic.ts
@@ -1,8 +1,7 @@
-import {Pressable, Text, Stack, StackItem, VisuallyHidden} from '../components';
+import {Pressable, Text, Stack, StackItem} from '../components';
 
 export type BasicComponents =
   | typeof Pressable
   | typeof Text
   | typeof Stack
-  | typeof StackItem
-  | typeof VisuallyHidden;
+  | typeof StackItem;

--- a/packages/argo-admin/src/components/VisuallyHidden.ts
+++ b/packages/argo-admin/src/components/VisuallyHidden.ts
@@ -1,8 +1,0 @@
-import {createRemoteComponent} from '@remote-ui/core';
-
-export interface VisuallyHiddenProps {}
-
-export const VisuallyHidden = createRemoteComponent<
-  'VisuallyHidden',
-  VisuallyHiddenProps
->('VisuallyHidden');


### PR DESCRIPTION
### Background

We recently added the `VisuallyHidden` component to `argo-admin` to support accessibility. However, as we investigated the implementation of this component in both the Android and iOS hosts, we discovered that it is not feasible and not the preferred approach to making content more accessible. In both Android and iOS, screen readers will not read invisible content.

### Solution

Remove the `VisibilityHidden` component from `argo-admin` to keep the available components consistent on all platforms.
