### PR TITLE
fix: remove stray visuallyhidden import

### DIFF
--- a/packages/argo-admin/src/components/index.ts
+++ b/packages/argo-admin/src/components/index.ts
@@ -19,4 +19,3 @@ export * from './StackItem';
 export * from './Text';
 export * from './TextField';
 export * from './Thumbnail';
-export * from './VisuallyHidden';


### PR DESCRIPTION
### Background

When removing the `VisuallyHidden` component, I missed an import.

### Solution

Remove `VisuallyHidden` import from `argo-admin` package
