### PR TITLE
Clean up root build folder when running yarn clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "nuke": "yarn run nuke && rm -rf ./node_modules",
     "build-consumer": "yarnpkg build && ./scripts/build-consumer.sh",
     "restore-consumer": "./scripts/restore-consumer.sh",
-    "clean": "git clean -xdf ./packages",
-    "clear-cache": "rm -rf .sewing-kit/cache"
+    "clean": "git clean -xdf ./packages; rm -rf ./build",
+    "clear-cache": "rm -rf .sewing-kit"
   },
   "devDependencies": {
     "@sewing-kit/cli": "^0.2.0",


### PR DESCRIPTION
### Background

Improve `yarn clean` and `yarn clear-cache` commands to remove all relevant files

### Solution

Related files were not cleaned up in the current commands so I made some improvements

### 🎩

1. Run `yarn build` and verify that built files (*.d.ts, *.esnext, *.js, *.mjs, anything inside `/build`) are created
2. Run `yarn clean` and verify that all built files are removed
3. Run `yarn clear-cache` and verify that the the `.sewing-kit` directory is delete

### Checklist

- [X] I have :tophat:'d these changes
